### PR TITLE
Handle exceptions in the constructor context when initializing the event handler and registrar

### DIFF
--- a/src/spellcheck32/spellcheck32.csproj
+++ b/src/spellcheck32/spellcheck32.csproj
@@ -19,7 +19,7 @@
 		<RepositoryUrl>https://github.com/willibrandon/spellcheck32</RepositoryUrl>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<Title>A .NET wrapper around the Microsoft Spell Checking API</Title>
-		<Version>1.0.5-alpha</Version>
+		<Version>1.0.6-alpha</Version>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Fixes #1 

Catch any exceptions that occur in the constructor context when initializing the SpellCheckerChanged event handler or the user dictionaries registrar and proceed with limited functionality.
   - If the SpellCheckerChanged event cannot be initialized, state change notifications will not be invoked.
   - If the dictionary registrar cannot be initialized, calls made to register or unregister user dictionaries will result in a no operation.